### PR TITLE
Update to new version 0.4.0 and new repository

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
-{% set version = "0.3.0" %}
+{% set version = "0.4.0" %}
 
 package:
     name: fabio
     version: {{ version }}
 
 source:
-    url: https://github.com/kif/fabio/archive/v{{ version }}.tar.gz
+    url: https://github.com/silx-kit/fabio/archive/v{{ version }}.tar.gz
     fn: fabio-v{{ version }}.tar.gz
-    sha256: ec4586a676dab02931bed2f1e0ef227c43259b4f60c0cfb603c30e02876164e8
+    sha256: ae1f2f979f801524558cac81ec8988d1eadce65b540cdeb46166162ae4788956
 
 build:
     number: 0
@@ -33,7 +33,7 @@ test:
         - fabio.third_party
 
 about:
-    home: https://github.com/kif/fabio
+    home: https://github.com/silx-kit/fabio
     license: GPL v3.0, GPL v2.0, MIT, GPL, LGPL v3.0, BSD 3-Clause, Apache 2.0
     summary: I/O library for images produced by 2D X-ray detector
     license_family: Other
@@ -44,3 +44,4 @@ extra:
         - ericdill
         - licode
         - tacaswell
+        - dmpelt


### PR DESCRIPTION
This PR updates the feedstock to the new 0.4.0 version and to the new repository (https://github.com/silx-kit/fabio).

Note: I am not involved in the development of `fabio` at all - I simply noticed that the current feedstock was using an older version when trying to install it. Also, this is the first `conda-forge` project I contribute to, so if I am doing something wrong, please let me know.
